### PR TITLE
Remove InMemoryStore from HealthServer constructor

### DIFF
--- a/tests/test_health.cpp
+++ b/tests/test_health.cpp
@@ -21,7 +21,6 @@ class HealthServer
 
     HealthServer()
     {
-        InMemoryStore store;
         configure_routes(svr, store);
         // run server on a background thread
         thread = std::thread([this] { svr.listen("127.0.0.1", port); });


### PR DESCRIPTION
Removed InMemoryStore instantiation from HealthServer constructor. Was declared twice, would cause issues when running tests