### PR TITLE
revert back cmakelists and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,18 @@ target_link_libraries(charizard_api_obj PRIVATE
   nlohmann_json::nlohmann_json
 )
 
+# Unit test target
+add_executable(charizard_unit_tests
+  tests/unit/test_health.cpp
+  $<TARGET_OBJECTS:charizard_api_obj>
+  # Any other unit test files to compile and run
+)
+target_include_directories(charizard_unit_tests PRIVATE
+  include
+  ${cpp_httplib_SOURCE_DIR}
+)
+target_link_libraries(charizard_unit_tests PRIVATE gtest_main nlohmann_json::nlohmann_json)
+
 add_test(NAME unit COMMAND charizard_unit_tests)
 
 # Integration (HTTP) test target

--- a/tests/unit/test_health.cpp
+++ b/tests/unit/test_health.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#define CPPHTTPLIB_THREAD_POOL_COUNT 2
+#include "api.hpp"
+#include "storage.hpp"
+
+#include <chrono>
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+#include <thread>
+
+using nlohmann::json;
+
+// Helper to start/stop the server for the test
+class HealthServer
+{
+  public:
+    InMemoryStore   store;
+    httplib::Server svr;
+    std::thread     thread;
+    int             port = 18080; // change if needed
+
+    HealthServer()
+    {
+        // Use the member `store` so the routes capture a reference that stays alive
+        configure_routes(svr, store);
+        // run server on a background thread
+        thread = std::thread([this] { svr.listen("127.0.0.1", port); });
+        std::this_thread::sleep_for(std::chrono::milliseconds(200)); // give server time to start
+    }
+
+    ~HealthServer()
+    {
+        svr.stop();
+        if (thread.joinable())
+            thread.join();
+    }
+};
+
+// TO-DO: place unit tests in unit/ directory
+TEST(CharizardAPI, HealthEndpoint)
+{
+    HealthServer server;
+
+    httplib::Client cli("127.0.0.1", server.port);
+    auto            res = cli.Get("/health");
+    ASSERT_TRUE(res != nullptr);
+    EXPECT_EQ(res->status, 200);
+
+    auto j = json::parse(res->body);
+    EXPECT_TRUE(j.contains("ok"));
+    EXPECT_TRUE(j["ok"].get<bool>());
+    EXPECT_EQ(j["service"], "charizard");
+}


### PR DESCRIPTION
Fixing things we removed in earlier PR. Working on #19 